### PR TITLE
센서 데이터 시각화용 Node-RED 대시보드 추가; docker-compose 기반 배포

### DIFF
--- a/services/docker-compose.yml
+++ b/services/docker-compose.yml
@@ -119,6 +119,16 @@ services:
       - /sys:/sys:ro
       - /var/lib/docker/:/var/lib/docker:ro
 
+# 4. Node-RED ()
+  nodered:
+    image: nodered/node-red
+    container_name: mynodered
+    restart: unless-stopped
+    ports:
+      - "1880:1880"
+    volumes:
+      - test_node_red_data:/data
 volumes:
   postgresqldata:
   redisdata:
+  test_node_red_data:


### PR DESCRIPTION
## Problem
- 현장은 MQTT Explorer의 raw JSON만 확인 가능
- 단위 변환과 직관적 차트가 없어 운영자가 해석에 시간 소요

## Solution
- `docker-compose`로 Node-RED를 배포하고 1880 포트로 접근 가능하게 구성
- MQTT 구독 후 단위 변환을 수행해 온도, 습도, 배터리를 각각 bar 차트로 시각화
- 대시보드는 기본 `node-red-dashboard` 사용
- 플로우 구조 적용
  `mqtt in → json → function 디코드 → Internal Temp / Internal Hum / Battery`
- 배터리 퍼센트(2980mV = 100%) 계산 로직 추가
- 차트 3종 구성  
  - Internal Temp (°C)
  - Internal Humidity (%)
  - Battery (%)
<img width="331" height="748" alt="image" src="https://github.com/user-attachments/assets/5aa6aec7-a890-4971-a560-f50862c7227c" />

## Changes
- `docker-compose.yml`에 nodered 서비스 추가 및 명명된 볼륨 반영

## Setting
: 이는 `docker run`을 통해 사전 반영됐으므로 실행 필요 X
```bash
# 1. docker-compose 기동
docker compose up -d

# 2. Node-RED 컨테이너에 대시보드 라이브러리 설치
docker exec -it mynodered bash
npm install node-red-dashboard
exit
docker restart mynodered
```

## Access
- 작성: http://100.95.67.20:1880/
- 대시보드: http://100.95.67.20:1880/ui

Fixes #3 