### PR TITLE
feat: add deployment workflow for RPi (#7)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,25 +21,21 @@ jobs:
           host: ${{ secrets.RPI_HOST }}
           username: ${{ secrets.RPI_USER }}
           password: ${{ secrets.RPI_PASSWORD }}
-            
-            docker-compose -f chirpstack/docker-compose.yml down || true
-            docker-compose -f infra/docker-compose.yml down || true
-            docker-compose -f chirpstack/docker-compose.yml up -d
-            docker-compose -f infra/docker-compose.yml up -d
-          
           script: |
             set -e
+            echo "=== 배포 시작 ==="
             cd ~/onlog-ef-rpi
+
+            # 최신 코드 가져오기
             git fetch origin main
             git reset --hard origin/main
 
-            # 최신 이미지 가져오기
+            echo "=== Docker 이미지 Pull ==="
             docker-compose -f chirpstack/docker-compose.yml pull
             docker-compose -f infra/docker-compose.yml pull
 
-            # 필요한 서비스 빌드
-            docker-compose -f infra/docker-compose.yml build mqtt-logger
-
-            # 변경된 부분만 반영
+            echo "=== 서비스 재시작 (변경만 반영) ==="
             docker-compose -f chirpstack/docker-compose.yml up -d --build
             docker-compose -f infra/docker-compose.yml up -d --build
+
+            echo "=== 배포 완료 ==="


### PR DESCRIPTION
## 📝 변경 사항 (Changes)  
- `.github/workflows/deploy.yml` 워크플로우 추가  
  - main 브랜치 push 시 자동 실행  
  - SSH 접속 후 `docker-compose pull + up -d --build`로 서비스 재배포  
- 불필요한 `down` 명령어 제거 → 배포 중단 시간 최소화  
- 배포 로그(`echo`) 추가 → 실행 로그 가독성 개선  

---

## ✅ 기대 효과 (Expected Result)  
- main 브랜치에 push 시 자동으로 RPi에 최신 코드 반영  
- 수동 배포 과정 최소화 → 협업 시 배포 누락 방지  
- 배포 효율성 향상 및 기본적인 안정성 확보  

---

## 🔜 다음 단계 (Follow-up, 별도 이슈 처리 예정)  
- SSH password → SSH key 기반 보안 강화  
- Docker Hub에 이미지 push → RPi는 `pull`만 수행하도록 구조 개선 
- 가능하다면, RPi 에서 watchtower 실행 시도

---

Closes #7
