### PR TITLE
chore: migrate deploy workflow to SSH key authentication (#9)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,7 +20,7 @@ jobs:
         with:
           host: ${{ secrets.RPI_HOST }}
           username: ${{ secrets.RPI_USER }}
-          password: ${{ secrets.RPI_SSH_KEY }}
+          key: ${{ secrets.RPI_SSH_KEY }}
           script: |
             set -e
             echo "=== 배포 시작 ==="


### PR DESCRIPTION
## 📝 변경 사항 (Changes)  
- GitHub Actions 워크플로우(`deploy.yml`)를 **SSH password → SSH key 인증 방식**으로 변경  
- `RPI_PASSWORD` secret 제거, `RPI_SSH_KEY` secret 사용  
- 배포 스크립트에서 `services/docker-compose.yml` 기준으로 수정  

---

## ✅ 기대 효과 (Expected Result)  
- GitHub Actions가 SSH key 인증을 통해 RPi에 안전하게 접속 가능  
- Password 기반 로그인 제거로 보안 강화  
- 배포 과정에서 인증 관련 에러 가능성 최소화  

---

Closes #9
