### PR TITLE
feat(ci): add runner-based deploy workflow (#17)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,7 +19,7 @@ jobs:
         run: |
             set -e
             echo "=== 배포 시작 ==="
-            cd ~/onlog-ef-rpi
+            cd "$GITHUB_WORKSPACE"
 
             # 최신 코드 가져오기
             git fetch origin main


### PR DESCRIPTION
# PR: Self-hosted Runner 기반 CI/CD 전환 (#17)

## 📌 개요
이번 PR은 RPi 배포 자동화를 위해 **GitHub Actions Self-hosted Runner**를 도입한 작업입니다.  
기존에는 여러 배포 방식을 고민했으나, 최종적으로 **RPi 내부 Runner 기반 배포**로 확정했습니다.

---

## 🤔 고민했던 선택지들

1. **SSH 방식**
   - GitHub Actions에서 `appleboy/ssh-action`을 통해 RPi 접속 후 `git pull && docker-compose up -d` 실행
   - 문제:  
     - Tailscale 100.x.x.x IP는 GitHub 클라우드 Runner가 직접 접근 불가  
     - 포트포워딩이나 Funnel 같은 추가 세팅 필요  
     - 보안성 떨어짐 (SSH key 관리 부담)

2. **AWS S3 동기화 방식**
   - GitHub Actions → 빌드 결과를 AWS S3 업로드 → RPi에서 `aws s3 sync`로 받아오기
   - 문제:  
     - S3 접근 키 관리 필요  
     - 인프라 오버헤드 (EC2/CodeArtifact까지 고려해야 함)  
     - 단일 RPi라면 과도한 구조

3. **DockerHub + Watchtower**
   - GitHub Actions에서 DockerHub push → RPi는 Watchtower로 자동 pull
   - 장점: 빠른 롤백, 여러 공장 RPi 확장 시 유리
   - 문제:  
     - infra 변경(docker-compose.yml 등)은 여전히 git pull 필요  
     - 지금 단계에서는 Runner만으로도 충분

4. **GitHub Actions → Tailscale 세션 방식**
   - GitHub Runner에서 Tailscale 세션 열고 100.x.x.x IP로 RPi 접속
   - 문제:  
     - GitHub 클라우드 Runner가 Tailscale에 join하기 까다로움
     - GitHub Actions Job 매번 시작할 때 Tailscale 세션을 맺어야 함
     - 세션 유지/보안 이슈 발생

---

## ✅ 최종 선택: Self-hosted Runner on RPi
- 각 RPi 내부에 Runner를 설치하여, main 브랜치 push 시 RPi에서 직접 `git pull && docker-compose pull/up` 수행
- 장점:
  - SSH 불필요 (보안 ↑)
  - infra 변경과 이미지 업데이트 모두 반영 가능
  - 공장 확장 시 RPi별 Runner만 설치하면 됨
- Runner는 `~/actions-runner` 경로에 두고, systemd 서비스로 등록하여 부팅 시 자동 실행되도록 구성

---

## 🛠️ 주요 변경 사항
- `.github/workflows/deploy.yml` 수정
  - 기존 SSH 기반 배포 제거
  - `runs-on: [self-hosted, rpi-ef]`로 지정하여 RPi Runner에서 실행되도록 변경
  - steps:
    - `git fetch/reset`으로 최신 코드 동기화
    - `docker-compose pull && up -d --build`로 서비스 업데이트

---

## 📸 실행 캡처 (첨부 예정)
- GitHub Actions 실행 로그 캡처
<img width="1714" height="1033" alt="image" src="https://github.com/user-attachments/assets/9aedd792-5b87-4088-a8e0-bb40c3a0a850" />

- GitHub Repository → Settings → Actions → Runners 화면 캡처 (`rpi-ef` Online 확인)
<img width="1317" height="396" alt="image" src="https://github.com/user-attachments/assets/db1f0c88-ebae-49ad-82d6-cbd4c287eb7a" />


---

## 🔗 Issue
- Closes #17

---

## 📝 비고
- 이번 PR에서 Runner를 RPi에 직접 설치하는 쪽으로 확정했지만,  
  추후 **여러 공장 운영 및 롤백 속도 향상 + Container App의 수 증가**로 인해 DockerHub + Watchtower 병행을 다시 고려할 수 있음.
- 현재는 **단순성과 확실성**을 우선으로 선택.
