### PR TITLE
fix(ci): migrate to docker compose v2 in deploy.yml (#19)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,9 +26,9 @@ jobs:
             git reset --hard origin/main
 
             echo "=== Docker 이미지 Pull ==="
-            docker-compose -f services/docker-compose.yml pull
+            docker compose -f services/docker-compose.yml pull
 
-            echo "=== 서비스 재시작 (변경만 반영) ==="
-            docker-compose -f services/docker-compose.yml up -d --build
+            echo "=== 서비스 재시작 ==="
+            docker compose -f services/docker-compose.yml up -d --build
 
             echo "=== 배포 완료 ==="


### PR DESCRIPTION
# [Bug] migrate to docker compose v2 in deploy.yml (#19)

## 📌 개요
- 기존 워크플로우에서 `docker-compose` 명령어를 사용했으나,  
  RPi 환경에는 Docker Compose v2 (`docker compose`)만 설치되어 있어 오류 발생.

## 🛠️ 변경 사항
- `.github/workflows/deploy.yml` 내 모든 `docker-compose` → `docker compose`로 수정

## 🔗 관련 이슈
Closes #19