### PR TITLE
fix: add --no-cache to deploy workflow and confirm stability

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,7 +28,13 @@ jobs:
             echo "=== Docker 이미지 Pull ==="
             docker compose -f services/docker-compose.yml pull
 
+            echo "=== 서비스 빌드 (no cache) ==="
+            docker compose -f services/docker-compose.yml build --no-cache
+
             echo "=== 서비스 재시작 ==="
-            docker compose -f services/docker-compose.yml up -d --build
+            docker compose -f services/docker-compose.yml up -d
+
+            echo "=== 현재 상태 ==="
+            docker compose -f services/docker-compose.yml ps
 
             echo "=== 배포 완료 ==="


### PR DESCRIPTION
# fix: add --no-cache to deploy workflow and confirm stability

## 작업 내용
- GitHub Actions 배포 워크플로우 수정
  - `docker compose build --no-cache` 추가하여 Dockerfile 변경 시 캐시 문제 방지
  - `pull → build --no-cache → up -d` 순서로 안정성 강화
- `.github/workflows/deploy.yml` 업데이트

## 테스트
- PR push 시 GitHub Actions 실행됨
- RPi self-hosted runner에서 `services/docker-compose.yml` 기준 배포 성공
- `docker compose ps` 결과 캡처 첨부 예정

## 특이 사항
- 이번 PR은 **최초로 CI/CD 배포가 안정적으로 성공한 기록** 🎉
- milestone 성격의 작업이라 캡처와 함께 팀 내 공유 예정

## 캡처
> 아래 스크린샷은 PR 머지 후 RPi에서 배포 성공을 확인한 결과입니다.
<img width="1880" height="637" alt="image" src="https://github.com/user-attachments/assets/f1a080d4-aaf9-4bff-963a-53b95391d3c3" />
<img width="1318" height="1500" alt="image" src="https://github.com/user-attachments/assets/6f600bb3-e139-426f-bca0-ecc58e8c8c10" />
<img width="1332" height="689" alt="image" src="https://github.com/user-attachments/assets/224b7947-38f4-4d47-8b72-0695393e4b75" />

---

close #21