### PR TITLE
[Infra] 배포 경로를 `$GITHUB_WORKSPACE` 기준으로 통합

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,14 +17,12 @@ This project provides a complete LoRaWAN gateway solution for Raspberry Pi, desi
 
 ```
 onlog-edangfood-rpi/
-├── chirpstack/              # LoRaWAN Network Server
+├── services/              # LoRaWAN Network Server
 │   ├── docker-compose.yml   # ChirpStack services
 │   ├── configuration/       # Regional LoRa configurations
 │   └── logger/              # Data logging application
 ├── deployment-scripts/      # Deployment automation
 │   └── get-docker.sh       # Docker installation script
-├── infra/                   # Infrastructure services
-│   └── docker-compose.yml   # Supporting services
 ├── monitoring/              # System monitoring
 │   └── node_exporter       # Prometheus Node Exporter
 └── README.md


### PR DESCRIPTION
# [Infra] 배포 경로를 `$GITHUB_WORKSPACE` 기준으로 통합

## 관련 이슈
close #23

## 배경
- 기존에는 RPi 로컬 clone(`~/onlog-ef-rpi`)을 기준으로 배포를 수행했으나,  
  GitHub Actions runner가 사용하는 `$GITHUB_WORKSPACE`는 항상 main 기준 최신 코드 상태이므로  
  결과적으로 로컬 clone은 단순 사본이 됨.
- 이로 인해 `chirpstack/` 같은 불필요한 잔여물이 남는 문제가 발생했음.

## 변경 사항
- 배포 기준 디렉토리를 `$GITHUB_WORKSPACE`로 고정
- 접근 편의를 위해 `$GITHUB_WORKSPACE` → `~/onlog-ef-rpi` 심볼릭 링크 생성
- deploy.yml 내 동작은 변경 없음 (이미 `$GITHUB_WORKSPACE` 사용 중)

## 기대 효과
- 항상 GitHub main과 동기화된 clean 상태에서 배포 보장
- 불필요한 로컬 잔여물 제거
- 배포 안정성 강화

## 캡처
<img width="1701" height="373" alt="image" src="https://github.com/user-attachments/assets/7cb47cd5-a6d4-435a-97a9-5367b7e0a5b1" />
