### PR TITLE
[infra] Node-RED 컨테이너 이름 충돌 문제 해결

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,13 +69,20 @@ onlog-edangfood-rpi/
 
 ## 🌐 Services
 
-| Service | Port | Description |
-|---------|------|-------------|
-| ChirpStack | 8080 | LoRaWAN Network Server Web UI |
-| PostgreSQL | 5432 | Database for ChirpStack |
-| Redis | 6379 | Session storage |
-| Mosquitto | 1883 | MQTT Broker |
-| Node Exporter | 9100 | System metrics |
+| Service                        | Port  | Description                                      |
+|--------------------------------|-------|--------------------------------------------------|
+| ChirpStack                     | 8080  | LoRaWAN Network Server Web UI                    |
+| ChirpStack REST API            | 8090  | REST API for ChirpStack                          |
+| ChirpStack Gateway Bridge      | 3001  | Gateway <-> Network Server bridge (BasicStation) |
+| PostgreSQL                     | 5432  | Database for ChirpStack                          |
+| Redis                          | 6379  | Session storage                                  |
+| Mosquitto                      | 1883  | MQTT Broker                                      |
+| Node Exporter                  | 9100* | System metrics                                   |
+| cAdvisor                       | 8081  | Container metrics (for Prometheus/Grafana)       |
+| Node-RED (mynodered container) | 1880  | Low-code flow-based programming tool             |
+| MQTT Logger                    | —     | Custom Python-based MQTT → SQLite logger         |
+
+\* Node Exporter는 기본 포트가 `9100`이지만 현재 compose 설정에는 호스트 포트 매핑이 없음.  
 
 ## 📊 Monitoring
 


### PR DESCRIPTION
close #25

## 변경 사항
- 배포 전에 기존 `mynodered` 컨테이너를 제거하는 단계 추가

## 기대 효과
- Node-RED 컨테이너 이름 충돌 방지
- 항상 `docker-compose.yml` 기준으로 Node-RED 서비스 recreate 보장