### PR TITLE
fix:node-red volume

### DIFF
--- a/services/docker-compose.yml
+++ b/services/docker-compose.yml
@@ -119,7 +119,7 @@ services:
       - /sys:/sys:ro
       - /var/lib/docker/:/var/lib/docker:ro
 
-# 4. Node-RED ()
+# 4. Node-RED (센서데이터 대시보드)
   nodered:
     image: nodered/node-red
     container_name: mynodered
@@ -127,8 +127,8 @@ services:
     ports:
       - "1880:1880"
     volumes:
-      - test_node_red_data:/data
+      - /mnt/nvme/infra/nodered:/data
+
 volumes:
   postgresqldata:
   redisdata:
-  test_node_red_data:


### PR DESCRIPTION
# Node-RED 데이터 볼륨을 바인드 마운트로 고정 (Compose 접두어 `services_` 문제 해결)

## Problem
- `docker run` 환경에서는 `test_node_red_data:/data` 사용  
- `docker-compose` 실행 시 Compose가 접두어(`services_`)를 붙여 `services_test_node_red_data` 볼륨 생성  
- 결과적으로 Node-RED 컨테이너가 기존 데이터가 아닌 새로운 볼륨을 사용 → 대시보드 및 플로우 초기화 발생  

## Solution
- `/mnt/nvme/infra/nodered` 디렉토리를 생성하고 기존 `test_node_red_data` 내용을 복사  
- `docker-compose.yml` 수정 → Node-RED의 `/data`를 host path로 바인드 마운트  
  ```yaml
  nodered:
    volumes:
      - /mnt/nvme/infra/nodered:/data
    ```

## Changes
- Node-RED 서비스의 볼륨 설정을 named volume → 바인드 마운트로 변경

## Checklist
- 기존 Node-RED 플로우 및 대시보드 데이터 유지 확인

Closes #29 