### PR TITLE
PR: Redis Metrics Exporter 주기 실행 기능 추가

### DIFF
--- a/services/redis-metrics-exporter/app.py
+++ b/services/redis-metrics-exporter/app.py
@@ -9,7 +9,7 @@ from datetime import datetime
 REDIS_HOST = os.getenv("REDIS_HOST", "redis")
 REDIS_PORT = int(os.getenv("REDIS_PORT", 6379))
 SQLITE_PATH = os.getenv("DB_PATH", "/data/redis_metrics.db")
-EXPORT_INTERVAL = int(os.getenv("EXPORT_INTERVAL", 3600))  # 기본 1시간(3600초)
+EXPORT_INTERVAL = int(os.getenv("EXPORT_INTERVAL", 3600))  # 기본 1시간(3600s)
 
 def init_db():
     conn = sqlite3.connect(SQLITE_PATH)


### PR DESCRIPTION
## 📌 PR: Redis Metrics Exporter 주기 실행 기능 추가

### 🚀 개요

기존 Redis → SQLite Exporter는 **1회 실행 후 종료**하는 구조였습니다.
이번 변경으로 Exporter가 **항상 실행되며, 일정 주기(기본 1시간)**마다 Redis 데이터를 SQLite에 적재하도록 개선했습니다.

---

### 🛠 변경 사항

* `app.py` 수정:

  * 무한 루프(`while True`) + `time.sleep(EXPORT_INTERVAL)` 구조 추가
  * `EXPORT_INTERVAL` 환경변수 지원 (기본 3600초 = 1시간)
  * export 실행 시 새로 삽입된 row 개수 로그 출력
  * timestamp 파싱 오류 시 `None` 반환 처리로 안전성 강화
* Docker Compose 환경에서 기존과 동일하게 컨테이너가 항상 실행됨

---

### 📊 주요 기능

* 컨테이너가 항상 켜져 있으며, 주기적으로 Redis metrics export 수행
* SQLite 중복 방지 (`INSERT OR IGNORE`) 적용 유지
* 실행 로그:

  ```
  ✅ Export 완료: 42 rows inserted
  ⏳ 다음 실행까지 3600초 대기
  ```
* 환경변수 `EXPORT_INTERVAL`로 주기 변경 가능

---

### ✅ 테스트

<img width="931" height="77" alt="image" src="https://github.com/user-attachments/assets/c703cc19-fa18-42e8-b1c4-f7c53c3d1ada" />


* 로컬에서 10초 주기로 테스트 시 정상 작동 확인
* Redis metrics key 769개 → SQLite row 769개 적재 일치 확인
* 새 key 추가 후 다음 주기에서 자동 반영 확인

---

### 🔮 향후 계획

* Kafka Producer 연동 시, SQLite insert → `producer.send()`로 손쉽게 교체 가능
* Export 주기를 동적으로 변경할 수 있는 API endpoint 추가 고려
* 장기적으로는 TimescaleDB, Parquet/S3 백엔드 저장소 지원 검토
