### PR TITLE
배터리 전압 기준 수정 (3300 mV)

### DIFF
--- a/services/battery-monitor/monitor_battery.py
+++ b/services/battery-monitor/monitor_battery.py
@@ -13,7 +13,7 @@ DB_PATH = "/mnt/nvme/infra/sqlite/sensor_logs.db"
 DEVICES_FILE = BASE_DIR / "devices.json"
 
 V_MIN = 2500  # 2.5 V
-V_MAX = 3000  # 3.0 V
+V_MAX = 3300  # 3.0 V
 KST = timezone(timedelta(hours=9))  # 한국 시간대
 
 


### PR DESCRIPTION
### 개요
LHT65N 센서의 실제 측정 결과, 최대 전압이 3.3 V(≈3300 mV)까지 도달함을 확인했습니다.  
이에 따라 `monitor_battery.py`의 상한값(`V_MAX`)을 기존 3000 mV → 3300 mV로 수정했습니다.

### 변경 사항
- `V_MAX = 3000` → `V_MAX = 3300`
- 배터리 퍼센트 계산식은 기존 로직 유지

### 테스트
- `python3 monitor_battery.py all` 실행 시  
  3250–3300 mV 센서가 100 %로 정상 표시되는 것 확인 완료.

### 이슈
- Issue #46 
