### PR TITLE
MSK Producer (Kafka producer) service in the Docker Compose

### DIFF
--- a/services/docker-compose.yml
+++ b/services/docker-compose.yml
@@ -143,18 +143,18 @@ services:
     volumes:
       - /mnt/nvme/infra/redis-metrics:/data
 
-  # # 6. MSK Producer (Kafka 프로듀서)
-  # msk-producer:
-  #   build:
-  #     context: ./msk-producer
-  #   container_name: onlog-msk-producer
-  #   restart: unless-stopped
-  #   environment:
-  #     AWS_REGION: ap-northeast-2
-  #     AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID}
-  #     AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY}
-  #   networks:
-  #     - default
+  # 6. MSK Producer (Kafka 프로듀서)
+  msk-producer:
+    build:
+      context: ./msk-producer
+    container_name: onlog-msk-producer
+    restart: unless-stopped
+    environment:
+      AWS_REGION: ap-northeast-2
+      AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID}
+      AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY}
+    networks:
+      - default
 
 volumes:
   postgresqldata:

--- a/services/msk-producer/Dockerfile
+++ b/services/msk-producer/Dockerfile
@@ -1,13 +1,13 @@
-# FROM eclipse-temurin:17-jre-jammy
+FROM eclipse-temurin:17-jre-jammy
 
-# WORKDIR /app
+WORKDIR /app
 
-# # 라이브러리 복사
-# COPY libs ./libs
-# COPY src ./src
+# 라이브러리 복사
+COPY libs ./libs
+COPY src ./src
 
-# # 컴파일
-# RUN javac -cp "libs/*" src/MskProducer.java
+# 컴파일
+RUN javac -cp "libs/*" src/MskProducer.java
 
-# # 실행
-# CMD ["java", "-cp", "src:libs/*", "MskProducer"]
+# 실행
+CMD ["java", "-cp", "src:libs/*", "MskProducer"]

--- a/services/msk-producer/src/MskProducer.java
+++ b/services/msk-producer/src/MskProducer.java
@@ -37,23 +37,29 @@ public class MskProducer {
 
         KafkaProducer<String, String> producer = new KafkaProducer<>(props);
 
-        ProducerRecord<String, String> record =
+        Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+            producer.close();
+        }));
+
+        while (true) {
+            ProducerRecord<String, String> record =
                 new ProducerRecord<>("onlog-test", "hello-from-rpi");
 
-        producer.send(record, (metadata, exception) -> {
-            if (exception != null) {
-                exception.printStackTrace();
-            } else {
-                System.out.println(
+            producer.send(record, (metadata, exception) -> {
+                if (exception != null) {
+                    exception.printStackTrace();
+                } else {
+                    System.out.println(
                         "SUCCESS: " +
                         metadata.topic() +
                         " partition=" + metadata.partition() +
                         " offset=" + metadata.offset()
-                );
-            }
-        });
+                    );
+                }
+            });
 
-        producer.flush();
-        producer.close();
+            producer.flush();
+            Thread.sleep(5000);
+        }
     }
 }

--- a/services/msk-producer/src/MskProducer.java
+++ b/services/msk-producer/src/MskProducer.java
@@ -1,59 +1,59 @@
-// import org.apache.kafka.clients.producer.*;
-// import org.apache.kafka.common.serialization.StringSerializer;
+import org.apache.kafka.clients.producer.*;
+import org.apache.kafka.common.serialization.StringSerializer;
 
-// import java.util.Properties;
+import java.util.Properties;
 
-// public class MskProducer {
+public class MskProducer {
 
-//     public static void main(String[] args) throws Exception {
+    public static void main(String[] args) throws Exception {
 
-//         Properties props = new Properties();
+        Properties props = new Properties();
 
-//         // MSK Private Bootstrap (IAM 포트)
-//         props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG,
-//                 "b-1.devmsk.xxxxxx.c3.kafka.ap-northeast-2.amazonaws.com:9098");
+        // MSK Private Bootstrap (IAM 포트)
+        props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG,
+                "b-1.devmsk.xxxxxx.c3.kafka.ap-northeast-2.amazonaws.com:9098");
 
-//         // Kafka 기본
-//         props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG,
-//                 StringSerializer.class.getName());
-//         props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG,
-//                 StringSerializer.class.getName());
-//         props.put(ProducerConfig.ACKS_CONFIG, "all");
+        // Kafka 기본
+        props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG,
+                StringSerializer.class.getName());
+        props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG,
+                StringSerializer.class.getName());
+        props.put(ProducerConfig.ACKS_CONFIG, "all");
 
-//         // ===== IAM + TLS 핵심 =====
-//         props.put("security.protocol", "SASL_SSL");
-//         props.put("sasl.mechanism", "AWS_MSK_IAM");
+        // ===== IAM + TLS 핵심 =====
+        props.put("security.protocol", "SASL_SSL");
+        props.put("sasl.mechanism", "AWS_MSK_IAM");
 
-//         props.put(
-//             "sasl.jaas.config",
-//             "software.amazon.msk.auth.iam.IAMLoginModule required;"
-//         );
+        props.put(
+            "sasl.jaas.config",
+            "software.amazon.msk.auth.iam.IAMLoginModule required;"
+        );
 
-//         props.put(
-//             "sasl.client.callback.handler.class",
-//             "software.amazon.msk.auth.iam.IAMClientCallbackHandler"
-//         );
-//         // =========================
+        props.put(
+            "sasl.client.callback.handler.class",
+            "software.amazon.msk.auth.iam.IAMClientCallbackHandler"
+        );
+        // =========================
 
-//         KafkaProducer<String, String> producer = new KafkaProducer<>(props);
+        KafkaProducer<String, String> producer = new KafkaProducer<>(props);
 
-//         ProducerRecord<String, String> record =
-//                 new ProducerRecord<>("onlog-test", "hello-from-rpi");
+        ProducerRecord<String, String> record =
+                new ProducerRecord<>("onlog-test", "hello-from-rpi");
 
-//         producer.send(record, (metadata, exception) -> {
-//             if (exception != null) {
-//                 exception.printStackTrace();
-//             } else {
-//                 System.out.println(
-//                         "SUCCESS: " +
-//                         metadata.topic() +
-//                         " partition=" + metadata.partition() +
-//                         " offset=" + metadata.offset()
-//                 );
-//             }
-//         });
+        producer.send(record, (metadata, exception) -> {
+            if (exception != null) {
+                exception.printStackTrace();
+            } else {
+                System.out.println(
+                        "SUCCESS: " +
+                        metadata.topic() +
+                        " partition=" + metadata.partition() +
+                        " offset=" + metadata.offset()
+                );
+            }
+        });
 
-//         producer.flush();
-//         producer.close();
-//     }
-// }
+        producer.flush();
+        producer.close();
+    }
+}


### PR DESCRIPTION
This pull request enables and finalizes the MSK Producer (Kafka producer) service in the Docker Compose setup, completes its Dockerfile, and implements the actual producer logic in Java. The changes collectively make the MSK Producer ready for use in development and testing environments.

**MSK Producer Service Enablement and Implementation:**

* Docker Compose:
  - The `msk-producer` service is uncommented and activated in `docker-compose.yml`, allowing it to be built and run as part of the stack.

* Dockerfile:
  - The `Dockerfile` for `msk-producer` is finalized by uncommenting all relevant instructions, ensuring the application is built, dependencies are copied, and the producer runs as intended.

* Java Producer Logic:
  - The `MskProducer.java` file is fully implemented (uncommented and updated) to continuously send test messages to the Kafka topic `onlog-test` every 5 seconds, with proper shutdown handling and AWS MSK IAM authentication.