### PR TITLE
feat: comment out MSK Producer service in docker-compose.yml

### DIFF
--- a/services/docker-compose.yml
+++ b/services/docker-compose.yml
@@ -143,19 +143,19 @@ services:
     volumes:
       - /mnt/nvme/infra/redis-metrics:/data
 
-  # 6. MSK Producer (Kafka 프로듀서)
-  msk-producer: 
-    build:
-      context: ./msk-producer
-    container_name: onlog-msk-producer
-    restart: unless-stopped
-    environment:
-      AWS_REGION: ap-northeast-2
-      AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID}
-      AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY}
-      KAFKA_BOOTSTRAP_SERVERS: b-1.devmsk.pn9ent.c3.kafka.ap-northeast-2.amazonaws.com:9098,b-2.devmsk.pn9ent.c3.kafka.ap-northeast-2.amazonaws.com:9098
-    networks:
-      - default
+  # # 6. MSK Producer (Kafka 프로듀서)
+  # msk-producer: 
+  #   build:
+  #     context: ./msk-producer
+  #   container_name: onlog-msk-producer
+  #   restart: unless-stopped
+  #   environment:
+  #     AWS_REGION: ap-northeast-2
+  #     AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID}
+  #     AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY}
+  #     KAFKA_BOOTSTRAP_SERVERS: b-1.devmsk.pn9ent.c3.kafka.ap-northeast-2.amazonaws.com:9098,b-2.devmsk.pn9ent.c3.kafka.ap-northeast-2.amazonaws.com:9098
+  #   networks:
+  #     - default
 
   # 7. Raw Data Sender (SQLite → Cloud API)
   raw-sender:


### PR DESCRIPTION
This pull request makes a minor update to the `docker-compose.yml` configuration by commenting out the `msk-producer` service definition. This means the MSK Producer (Kafka producer) container will no longer be started as part of the Docker Compose stack, but the configuration is preserved in comments for future reference or reactivation.

- Commented out the entire `msk-producer` service section in `services/docker-compose.yml`, disabling its deployment while retaining its configuration for potential future use.